### PR TITLE
new clientid per trackingid change

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -430,7 +430,12 @@ if (localeDropdown && locale) localeDropdown.value = locale;
 
 function goToJamboreePage(newJamboree, newLocale) {
   if (!newJamboree || !newLocale) return;
+  const { jamboree: currentTrackingId } = getCurrentJamboreeAndLocale();
   const pathname = window.location.pathname;
+  if (newJamboree !== currentTrackingId && window.location.hostname === "localhost") {
+    localStorage.removeItem("visitorId");
+    document.cookie = "coveo_visitorId=; Max-Age=0; Path=/; SameSite=Lax";
+  }
   window.location.href = `${pathname}?tracking_id=${newJamboree}&locale=${newLocale}`;
 }
 


### PR DESCRIPTION
## [QA-2037](https://coveord.atlassian.net/browse/QA-2037)

### Description

When the Tracking ID changes on localhost, reset both persisted Relay client-ID stores before navigation:

remove localStorage["visitorId"]
expire the host-only coveo_visitorId cookie
This prevents the same client ID from being reused across Tracking IDs, avoiding Tracking ID data health errors in Coveo Data Health.

Validated manually with jamboree_2 → jamboree_3: the destination request, localStorage value, and cookie all received a new client ID.

