### PR TITLE
Migrate to search token

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,11 @@
+# Server-side config (used by token service — not bundled into client)
+COVEO_ORG_ID=jamboreextqcrdy3
+COVEO_ENVIRONMENT=dev
+
+# Client-side config (VITE_ prefix = inlined into the browser bundle at build time)
 VITE_ORGANIZATION_ID=jamboreextqcrdy3
 VITE_ENVIRONMENT=dev
+
 VITE_SEARCH_URL=https://sports-dev.barca.group/search
 VITE_LISTING_1_URL=https://sports-dev.barca.group/plp/accessories/surf-accessories
 VITE_LISTING_2_URL=https://sports-dev.barca.group/plp/clothing/pants

--- a/.env
+++ b/.env
@@ -1,7 +1,3 @@
-# Server-side config (used by token service — not bundled into client)
-COVEO_ORG_ID=jamboreextqcrdy3
-COVEO_ENVIRONMENT=dev
-
 # Client-side config (VITE_ prefix = inlined into the browser bundle at build time)
 VITE_ORGANIZATION_ID=jamboreextqcrdy3
 VITE_ENVIRONMENT=dev

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,6 @@
 # Copy this file to .env.local and fill in the API key.
 #
-# Create an API key in the Coveo admin console for org jamboreextqcrdy3:
+# Create an API key in the Coveo admin console for the org specified by COVEO_ORG_ID in .env:
 # - Use the "Authenticated Search" template
 # - This grants only the "Impersonate" privilege (minimum required)
 # - The key can mint anonymous search tokens but cannot execute queries or admin ops

--- a/.env.local.example
+++ b/.env.local.example
@@ -5,5 +5,9 @@
 # - This grants only the "Impersonate" privilege (minimum required)
 # - The key can mint anonymous search tokens but cannot execute queries or admin ops
 #
+# Alternatively, for local dev you can use a short-lived superuser token from:
+# https://platformdev.cloud.coveo.com/token
+# (expires after 4 hours but has all required privileges)
+#
 # See README.md for full setup instructions.
 COVEO_API_KEY="xx********-****-****-****-************"

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,9 @@
-# Copy this file to .env.local and fill in the token
-# Create an anonymous search token in barcasportsmcy01fvu
-# or get a temporary token from here: https://platformdev.cloud.coveo.com/token
-VITE_NEW_ACCESS_TOKEN="xx********-****-****-****-************"
-VITE_SEARCH_TOKEN="ey*****************************************..."
+# Copy this file to .env.local and fill in the API key.
+#
+# Create an API key in the Coveo admin console for org jamboreextqcrdy3:
+# - Use the "Authenticated Search" template
+# - This grants only the "Impersonate" privilege (minimum required)
+# - The key can mint anonymous search tokens but cannot execute queries or admin ops
+#
+# See README.md for full setup instructions.
+COVEO_API_KEY="xx********-****-****-****-************"

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,13 +1,18 @@
-# Copy this file to .env.local and fill in the API key.
+# Copy this file to .env.local and fill in the values.
+# These same variables must also be set in the Netlify site settings for production.
 #
-# Create an API key in the Coveo admin console for the org specified by COVEO_ORG_ID in .env:
-# - Use the "Authenticated Search" template
-# - This grants only the "Impersonate" privilege (minimum required)
-# - The key can mint anonymous search tokens but cannot execute queries or admin ops
+# COVEO_API_KEY:
+#   Create an API key in the Coveo admin console for the org specified by COVEO_ORG_ID:
+#   - Use the "Authenticated Search" template
+#   - This grants only the "Impersonate" privilege (minimum required)
+#   - The key can mint anonymous search tokens but cannot execute queries or admin ops
 #
-# Alternatively, for local dev you can use a short-lived superuser token from:
-# https://platformdev.cloud.coveo.com/token
-# (expires after 4 hours but has all required privileges)
+#   Alternatively, for local dev you can use a short-lived superuser token from:
+#   https://platformdev.cloud.coveo.com/token
+#   (expires after 4 hours but has all required privileges)
 #
 # See README.md for full setup instructions.
+
 COVEO_API_KEY="xx********-****-****-****-************"
+COVEO_ORG_ID="jamboreextqcrdy3"
+COVEO_ENVIRONMENT="dev"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The storefront uses **server-generated search tokens** instead of API keys direc
 
 ### Creating the API key
 
-In the [Coveo admin console](https://platformdev.cloud.coveo.com/) for org `jamboreextqcrdy3`:
+In the [Coveo admin console](https://platformdev.cloud.coveo.com/) for the org specified by `COVEO_ORG_ID` in `.env`:
 
 1. Go to **Organization** → **API Keys**
 2. Click **Add key**

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ cp .env.local.example .env.local
 npm run dev
 ```
 
+For `COVEO_API_KEY` you can use either:
+- The dedicated "Jamboree search-token generation" API key (ask a teammate or create one per the instructions above)
+- A short-lived superuser token from https://platformdev.cloud.coveo.com/token — works fine for local dev since it has all privileges including Impersonate (expires after 4 hours)
+
 The Vite token plugin automatically exposes `/api/token` during dev. No separate server needed.
 
 ### Production setup (Netlify)

--- a/README.md
+++ b/README.md
@@ -118,9 +118,16 @@ The Vite token plugin automatically exposes `/api/token` during dev. No separate
 
 ### Production setup (Netlify)
 
-Add `COVEO_API_KEY` as an environment variable in the Netlify site settings:
+Add the following environment variables in the Netlify site settings:
 - Site dashboard → **Site configuration** → **Environment variables** → **Add a variable**
-- Key: `COVEO_API_KEY`, Value: your authenticated search API key
+
+| Variable | Value |
+|----------|-------|
+| `COVEO_API_KEY` | Your authenticated search API key |
+| `COVEO_ORG_ID` | The Coveo organization ID (must match `VITE_ORGANIZATION_ID` in `.env`) |
+| `COVEO_ENVIRONMENT` | The platform environment: `dev`, `stg`, or `prod` (must match `VITE_ENVIRONMENT` in `.env`) |
+
+These are the same variables listed in `.env.local.example`. If the org or environment changes, update both the `.env` file (for the client bundle) and the Netlify env vars (for the serverless function).
 
 The Netlify function at `netlify/functions/token.js` handles token generation in production.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install
 cp .env.local.example .env.local
 ```
 
-Edit `.env.local` and set your Coveo access token. You can get a short-lived superuser token at https://platformdev.cloud.coveo.com/token, or generate an anonymous search API key in the platform.
+Edit `.env.local` and set your `COVEO_API_KEY`. See the [Search Token Service](#search-token-service) section below for how to create this key.
 
 `npm install` automatically copies Atomic language and asset files into `public/` via the postinstall hook.
 
@@ -45,13 +45,20 @@ Within a jamboree, switching locale is instant (no page reload). Switching track
 ```
 app.html              ← SPA entry point
 index.html            ← Landing page (jamboree picker)
-vite.config.js        ← Build config + dev/preview rewrite middleware
+vite.config.js        ← Build config + dev/preview rewrite + token plugin
+netlify.toml          ← Netlify deploy config + /api/token redirect
 scripts/              ← Build tooling (resource copying)
+server/
+└── token.js          ← Shared token generation logic (used by Vite plugin + Netlify function)
+netlify/
+└── functions/
+    └── token.js      ← Netlify serverless function wrapper
 public/               ← Static assets (gitignored, populated by postinstall)
 src/
-├── main.js           ← App entry, routing setup
-├── router.js         ← Hash-based SPA router
-├── engine.js         ← Coveo commerce engine singleton
+├── main.js           ← App entry, routing setup (awaits engine)
+├── router.js         ← Pathname-based SPA router
+├── engine.js         ← Coveo commerce engine (async init + token renewal)
+├── tokenClient.js    ← Client-side token fetch with retry
 ├── configHelper.js   ← Env var resolution (jamboree/locale from URL)
 ├── commerceApi.js    ← Direct API calls (product detail page)
 ├── components/       ← Navbar, info banner, badge custom element
@@ -67,3 +74,52 @@ src/
 - Netlify rewrites serve the same built `app.html` for all `/jamboree_*/` paths
 - The Vite dev/preview server includes middleware that does the same rewriting locally
 - Page markup lives in `src/pages/templates/*.html` and is inlined into the JS bundle at build time
+
+## Search Token Service
+
+The storefront uses **server-generated search tokens** instead of API keys directly in the browser. This is required because API keys do not support [dictionary field retrieval](https://docs.coveo.com/en/2036/), which is needed for multi-language pricing and product data.
+
+### How it works
+
+1. The browser calls `GET /api/token` (handled by the Vite plugin in dev, Netlify function in prod)
+2. The server uses the `COVEO_API_KEY` to call the Coveo platform's `/rest/search/v2/token` endpoint
+3. The platform returns a short-lived JWT search token (≤24h validity, `ey...` format)
+4. The browser uses this token for all search/listing/recommendation requests
+5. When the token expires, the Headless engine's `renewAccessToken` callback automatically fetches a fresh one — no manual intervention needed
+
+### Creating the API key
+
+In the [Coveo admin console](https://platformdev.cloud.coveo.com/) for org `jamboreextqcrdy3`:
+
+1. Go to **Organization** → **API Keys**
+2. Click **Add key**
+3. Select the **"Authenticated Search"** template
+4. This grants only the **"Impersonate"** privilege — the minimum required to mint search tokens
+
+The resulting key:
+- **Can** generate anonymous search tokens (which support dictionary fields)
+- **Cannot** execute queries directly, read/write indexed content, or perform any administrative operations
+
+This key is the only secret in the project. It lives server-side and never reaches the browser bundle.
+
+### Local development setup
+
+```sh
+cp .env.local.example .env.local
+# Edit .env.local and paste your COVEO_API_KEY value
+npm run dev
+```
+
+The Vite token plugin automatically exposes `/api/token` during dev. No separate server needed.
+
+### Production setup (Netlify)
+
+Add `COVEO_API_KEY` as an environment variable in the Netlify site settings:
+- Site dashboard → **Site configuration** → **Environment variables** → **Add a variable**
+- Key: `COVEO_API_KEY`, Value: your authenticated search API key
+
+The Netlify function at `netlify/functions/token.js` handles token generation in production.
+
+### Token renewal
+
+Token renewal is fully automatic. The Coveo Headless engine detects expired tokens (HTTP 419) and calls the `renewAccessToken` callback, which fetches a fresh token from `/api/token`. This happens transparently — no page reload or user action required. Long QA sessions (>24h) work without interruption.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,10 @@
+# Token service — Netlify Functions v2 handles routing via config.path,
+# but this redirect serves as a fallback.
+[[redirects]]
+  from = "/api/token"
+  to = "/.netlify/functions/token"
+  status = 200
+
 # Rewrite app routes to the single-build app.
 # The app resolves its config from query params at runtime.
 

--- a/netlify/functions/token.js
+++ b/netlify/functions/token.js
@@ -1,0 +1,28 @@
+// Netlify Functions v2 — serverless token endpoint.
+// Mirrors the Vite dev plugin behavior in production.
+
+import { generateToken } from "../../server/token.js";
+
+export default async (req) => {
+  if (req.method !== "GET") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const result = await generateToken(process.env);
+
+  return new Response(
+    JSON.stringify(result.ok ? { token: result.token } : { error: result.error }),
+    {
+      status: result.ok ? 200 : result.status,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
+    }
+  );
+};
+
+export const config = { path: "/api/token" };

--- a/server/token.js
+++ b/server/token.js
@@ -1,0 +1,59 @@
+// Shared Coveo search-token generation logic.
+// Used by both the Vite dev plugin and the Netlify serverless function.
+// No framework dependencies — pure ES module with fetch.
+
+const ORG_ID = "jamboreextqcrdy3";
+const TOKEN_ENDPOINT = `https://platformdev.cloud.coveo.com/rest/search/v2/token?organizationId=${ORG_ID}`;
+
+/**
+ * Generate a short-lived anonymous Coveo search token.
+ * @param {Record<string, string|undefined>} env - Environment variables (process.env or Vite loadEnv output)
+ * @returns {Promise<{ok: true, token: string} | {ok: false, status: number, error: string}>}
+ */
+export async function generateToken(env) {
+  const apiKey = env.COVEO_API_KEY;
+
+  if (!apiKey) {
+    return { ok: false, status: 500, error: "Missing COVEO_API_KEY" };
+  }
+
+  try {
+    const response = await fetch(TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        userIds: [{ name: "anonymous", provider: "Email Security Provider" }],
+        allowedDictionaryFieldKeys: {
+          ec_name: ["*"],
+          ec_description: ["*"],
+          ec_colors: ["*"],
+          ec_price: ["*"],
+          ec_promo_price: ["*"],
+          cat_material: ["*"],
+          multilingualbody: ["*"],
+        },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        error: `Token request failed: ${response.status}`,
+      };
+    }
+
+    const { token } = await response.json();
+    return { ok: true, token };
+  } catch (err) {
+    if (err.name === "TimeoutError") {
+      return { ok: false, status: 500, error: "Token request timed out" };
+    }
+    console.error("[coveo-token]", err);
+    return { ok: false, status: 500, error: "Internal server error" };
+  }
+}

--- a/server/token.js
+++ b/server/token.js
@@ -2,8 +2,16 @@
 // Used by both the Vite dev plugin and the Netlify serverless function.
 // No framework dependencies — pure ES module with fetch.
 
-const ORG_ID = "jamboreextqcrdy3";
-const TOKEN_ENDPOINT = `https://platformdev.cloud.coveo.com/rest/search/v2/token?organizationId=${ORG_ID}`;
+/**
+ * Get the token endpoint URL for the given org and environment.
+ */
+function getTokenEndpoint(orgId, environment) {
+  let base;
+  if (environment === "dev") base = "https://platformdev.cloud.coveo.com";
+  else if (environment === "stg") base = "https://platformstg.cloud.coveo.com";
+  else base = "https://platform.cloud.coveo.com";
+  return `${base}/rest/search/v2/token?organizationId=${orgId}`;
+}
 
 /**
  * Generate a short-lived anonymous Coveo search token.
@@ -12,13 +20,19 @@ const TOKEN_ENDPOINT = `https://platformdev.cloud.coveo.com/rest/search/v2/token
  */
 export async function generateToken(env) {
   const apiKey = env.COVEO_API_KEY;
+  const orgId = env.COVEO_ORG_ID;
+  const environment = env.COVEO_ENVIRONMENT || "dev";
 
   if (!apiKey) {
     return { ok: false, status: 500, error: "Missing COVEO_API_KEY" };
   }
 
+  if (!orgId) {
+    return { ok: false, status: 500, error: "Missing COVEO_ORG_ID" };
+  }
+
   try {
-    const response = await fetch(TOKEN_ENDPOINT, {
+    const response = await fetch(getTokenEndpoint(orgId, environment), {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,

--- a/server/token.js
+++ b/server/token.js
@@ -46,6 +46,7 @@ export async function generateToken(env) {
           ec_colors: ["*"],
           ec_price: ["*"],
           ec_promo_price: ["*"],
+          ec_category: ["*"],
           cat_material: ["*"],
           multilingualbody: ["*"],
         },

--- a/server/token.js
+++ b/server/token.js
@@ -20,8 +20,8 @@ function getTokenEndpoint(orgId, environment) {
  */
 export async function generateToken(env) {
   const apiKey = env.COVEO_API_KEY;
-  const orgId = env.COVEO_ORG_ID;
-  const environment = env.COVEO_ENVIRONMENT || "dev";
+  const orgId = env.COVEO_ORG_ID || env.VITE_ORGANIZATION_ID;
+  const environment = env.COVEO_ENVIRONMENT || env.VITE_ENVIRONMENT || "dev";
 
   if (!apiKey) {
     return { ok: false, status: 500, error: "Missing COVEO_API_KEY" };

--- a/src/commerceApi.js
+++ b/src/commerceApi.js
@@ -1,20 +1,46 @@
-// This helper is for direct calls to the search API that bypass the atomic engine. Used for the PDP product retrieval.
+// This helper is for direct calls to the search API that bypass the atomic engine.
+// Used for PDP product retrieval and badge fetching.
 
 import { getEnvValue, getJamboree, getLocaleContext } from "./configHelper";
 import { navUrls } from "./components/navbar";
+import { fetchToken } from "./tokenClient.js";
 
-const {
-  VITE_ORGANIZATION_ID,
-  VITE_ENVIRONMENT,
-  VITE_NEW_ACCESS_TOKEN,
-  VITE_SEARCH_TOKEN,
-} = import.meta.env;
-
-// VITE_NEW_ACCESS_TOKEN is a transitional name — revert to VITE_ACCESS_TOKEN when ready
-const LOGGED_IN = localStorage.getItem("logged-in") === "true";
-const ACCESS_TOKEN = LOGGED_IN ? VITE_SEARCH_TOKEN : VITE_NEW_ACCESS_TOKEN;
+const { VITE_ORGANIZATION_ID, VITE_ENVIRONMENT } = import.meta.env;
 
 const TRACKING_ID = `jamboree_${getJamboree()}`;
+
+// Token cache for direct API calls
+let cachedToken = null;
+
+async function getToken() {
+  if (!cachedToken) {
+    cachedToken = await fetchToken();
+  }
+  return cachedToken;
+}
+
+/**
+ * Fetch wrapper that adds Authorization header and retries on token expiry (401/419).
+ */
+async function authenticatedFetch(url, options = {}) {
+  let token = await getToken();
+  let res = await fetch(url, {
+    ...options,
+    headers: { ...options.headers, Authorization: `Bearer ${token}` },
+  });
+
+  // Token expired — refresh and retry once
+  if (res.status === 401 || res.status === 419) {
+    cachedToken = null;
+    token = await getToken();
+    res = await fetch(url, {
+      ...options,
+      headers: { ...options.headers, Authorization: `Bearer ${token}` },
+    });
+  }
+
+  return res;
+}
 
 const generateClientId = () => {
   return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
@@ -50,10 +76,9 @@ export const searchProduct = async (productId, options = {}) => {
     },
   };
 
-  const response = await fetch(url, {
+  const response = await authenticatedFetch(url, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${ACCESS_TOKEN}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
@@ -118,10 +143,9 @@ export const fetchBadges = async (productId, placementIds) => {
     clientId: generateClientId(),
   };
 
-  const response = await fetch(url, {
+  const response = await authenticatedFetch(url, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${ACCESS_TOKEN}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -68,8 +68,6 @@ document.querySelector("#nav-bar").innerHTML = `
     <span class="d-inline-flex align-items-center ms-auto me-4">
       <label for="qa-info-toggle" class="fs-6 me-2">Show QA Info</label>
       <input type="checkbox" id="qa-info-toggle" />
-      <label for="logged-in-toggle" class="fs-6 ms-3 me-2">Logged In</label>
-      <input type="checkbox" id="logged-in-toggle" />
     </span>
   </div>
 `;
@@ -367,7 +365,6 @@ document
   });
 // --- QA Info toggle logic ---
 const qaInfoToggle = document.getElementById("qa-info-toggle");
-const loggedInToggle = document.getElementById("logged-in-toggle");
 
 function setQAInfoVisibility(visible) {
   document.querySelectorAll(".qa-info").forEach((el) => {
@@ -383,19 +380,9 @@ qaInfoToggle?.addEventListener("change", (e) => {
   setQAInfoVisibility(e.target.checked);
 });
 
-// --- Logged In toggle logic ---
-loggedInToggle?.addEventListener("change", (e) => {
-  localStorage.setItem("logged-in", e.target.checked ? "true" : "false");
-  window.location.reload();
-});
-
 // Ensure initial state: box unchecked, tags hidden
 if (qaInfoToggle) qaInfoToggle.checked = false;
 setQAInfoVisibility(false);
-if (loggedInToggle) {
-  const loggedInValue = localStorage.getItem("logged-in");
-  loggedInToggle.checked = loggedInValue === "true";
-}
 
 // --- Dropdown logic ---
 const propertyDropdown = document.getElementById("property-dropdown");

--- a/src/engine.js
+++ b/src/engine.js
@@ -2,52 +2,62 @@ import { buildCommerceEngine } from "@coveo/headless/commerce";
 import { buildContext } from "@coveo/headless/commerce";
 import { buildRecommendations } from "@coveo/headless/commerce";
 import { getJamboree, getLocaleContext, setLocaleSlug, parseLocaleSlug } from "./configHelper";
+import { fetchToken } from "./tokenClient.js";
 
-const {
-  VITE_ORGANIZATION_ID,
-  VITE_ENVIRONMENT,
-  VITE_NEW_ACCESS_TOKEN,
-  VITE_SEARCH_TOKEN,
-} = import.meta.env;
-
-// Use VITE_SEARCH_TOKEN if 'logged-in' is true in localStorage
-const LOGGED_IN = localStorage.getItem("logged-in") === "true";
-const ACCESS_TOKEN = LOGGED_IN ? VITE_SEARCH_TOKEN : VITE_NEW_ACCESS_TOKEN;
+const { VITE_ORGANIZATION_ID, VITE_ENVIRONMENT } = import.meta.env;
 
 const TRACKING_ID = `jamboree_${getJamboree()}`;
 const { language: LANGUAGE, country: COUNTRY, currency: CURRENCY } = getLocaleContext();
 
-export const commerceEngine = buildCommerceEngine({
-  configuration: {
-    organizationId: VITE_ORGANIZATION_ID,
-    environment: VITE_ENVIRONMENT,
-    accessToken: ACCESS_TOKEN,
-    analytics: {
-      trackingId: TRACKING_ID,
-    },
-    context: {
-      language: LANGUAGE,
-      country: COUNTRY,
-      currency: CURRENCY,
-      view: {
-        url: window.location.href,
+/**
+ * Initialize the commerce engine with a fresh search token.
+ * Exported as a Promise so consumers can `await engineReady`.
+ */
+export const engineReady = initEngine();
+
+/** Mutable reference to the resolved engine instance. */
+export let commerceEngine = null;
+
+async function initEngine() {
+  const token = await fetchToken();
+
+  const engine = buildCommerceEngine({
+    configuration: {
+      organizationId: VITE_ORGANIZATION_ID,
+      environment: VITE_ENVIRONMENT,
+      accessToken: token,
+      renewAccessToken: () => fetchToken(),
+      analytics: {
+        trackingId: TRACKING_ID,
+      },
+      context: {
+        language: LANGUAGE,
+        country: COUNTRY,
+        currency: CURRENCY,
+        view: {
+          url: window.location.href,
+        },
+      },
+      preprocessRequest: (request) => {
+        const body = request.body ? JSON.parse(request.body) : {};
+        if (request.url && request.url.includes("/listing")) {
+          const sponsoredProducts =
+            JSON.parse(localStorage.getItem("sponsored-products") || "{}") || {};
+          body.pinnedProducts = sponsoredProducts?.sponsored || [];
+        }
+        request.body = JSON.stringify(body);
+        return request;
       },
     },
-    preprocessRequest: (request) => {
-      const body = request.body ? JSON.parse(request.body) : {};
-      if (request.url && request.url.includes("/listing")) {
-        const sponsoredProducts =
-          JSON.parse(localStorage.getItem("sponsored-products") || "{}") || {};
-        body.pinnedProducts = sponsoredProducts?.sponsored || [];
-      }
-      request.body = JSON.stringify(body);
-      return request;
-    },
-  },
-});
+  });
 
-// Context controller for updating view URL on navigation
-const contextController = buildContext(commerceEngine);
+  commerceEngine = engine;
+  window.__commerceEngine = engine; // Expose for devtools debugging
+  return engine;
+}
+
+// Context controller — created lazily after engine resolves
+let contextController = null;
 
 /**
  * Update the engine's view URL when navigating between pages.
@@ -55,6 +65,10 @@ const contextController = buildContext(commerceEngine);
  * @param {string} url - The URL corresponding to the current page/view
  */
 export function setViewUrl(url) {
+  if (!commerceEngine) return;
+  if (!contextController) {
+    contextController = buildContext(commerceEngine);
+  }
   contextController.setView({ url });
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import "./qa-info.js";
 import "./shared/initAtomicLoader.js";
 import "./components/badgePlacement.js";
 import "./components/navbar.js";
+import { engineReady } from "./engine.js";
 import { registerRoute, initRouter } from "./router.js";
 import { searchPage } from "./pages/search.js";
 import { listing1Page, listing2Page, listing3Page } from "./pages/listing.js";
@@ -17,5 +18,25 @@ registerRoute("/recs1", recs1Page);
 registerRoute("/recs2", recs2Page);
 registerRoute("/pdp", pdpPage);
 
-// Start the router
-initRouter();
+// Show loading spinner while fetching token
+document.getElementById("app").innerHTML = `
+  <div class="d-flex justify-content-center align-items-center" style="min-height: 200px;">
+    <div class="spinner-border text-primary" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
+`;
+
+// Wait for engine to be ready with a valid token, then start routing
+try {
+  await engineReady;
+  initRouter();
+} catch (err) {
+  document.getElementById("app").innerHTML = `
+    <div class="alert alert-danger text-center my-5">
+      <h4>Search service unavailable</h4>
+      <p>${err.message}</p>
+      <p>Check that <code>COVEO_API_KEY</code> is configured correctly.</p>
+    </div>
+  `;
+}

--- a/src/tokenClient.js
+++ b/src/tokenClient.js
@@ -1,0 +1,33 @@
+/**
+ * Client-side token fetch module.
+ * Fetches search tokens from the server-side /api/token endpoint.
+ * Retries once after 1 second on failure.
+ */
+
+/**
+ * Fetch a search token from the token service.
+ * @returns {Promise<string>} The search token JWT (ey... format)
+ */
+export async function fetchToken() {
+  try {
+    return await doFetch();
+  } catch {
+    // Retry once after 1 second
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    return doFetch();
+  }
+}
+
+async function doFetch() {
+  const res = await fetch("/api/token", {
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Token fetch failed: ${res.status}`);
+  }
+
+  const { token } = await res.json();
+  return token;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,32 @@ import { generateToken } from "./server/token.js";
 // Closure variable for the token plugin — shared between configResolved and configureServer
 let tokenEnv = {};
 
+// Shared middleware used by both dev and preview servers
+async function tokenMiddleware(req, res, next) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (url.pathname !== "/api/token") return next();
+
+  if (req.method !== "GET") {
+    res.statusCode = 405;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({ error: "Method not allowed" }));
+    return;
+  }
+
+  const result = await generateToken(tokenEnv);
+
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", "no-store");
+
+  if (result.ok) {
+    res.statusCode = 200;
+    res.end(JSON.stringify({ token: result.token }));
+  } else {
+    res.statusCode = result.status;
+    res.end(JSON.stringify({ error: result.error }));
+  }
+}
+
 export default defineConfig({
   base: "/",
   build: {
@@ -74,30 +100,11 @@ export default defineConfig({
         tokenEnv = loadEnv(config.mode, config.root, "");
       },
       configureServer(server) {
-        server.middlewares.use(async (req, res, next) => {
-          const url = new URL(req.url, `http://${req.headers.host}`);
-          if (url.pathname !== "/api/token") return next();
-
-          if (req.method !== "GET") {
-            res.statusCode = 405;
-            res.setHeader("Content-Type", "application/json");
-            res.end(JSON.stringify({ error: "Method not allowed" }));
-            return;
-          }
-
-          const result = await generateToken(tokenEnv);
-
-          res.setHeader("Content-Type", "application/json");
-          res.setHeader("Cache-Control", "no-store");
-
-          if (result.ok) {
-            res.statusCode = 200;
-            res.end(JSON.stringify({ token: result.token }));
-          } else {
-            res.statusCode = result.status;
-            res.end(JSON.stringify({ error: result.error }));
-          }
-        });
+        const plugin = this;
+        server.middlewares.use(tokenMiddleware);
+      },
+      configurePreviewServer(server) {
+        server.middlewares.use(tokenMiddleware);
       },
     },
   ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,9 @@
 import { resolve } from "path";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
+import { generateToken } from "./server/token.js";
+
+// Closure variable for the token plugin — shared between configResolved and configureServer
+let tokenEnv = {};
 
 export default defineConfig({
   base: "/",
@@ -59,6 +63,40 @@ export default defineConfig({
           }
 
           next();
+        });
+      },
+    },
+    // Token service plugin — exposes GET /api/token during dev
+    {
+      name: "coveo-token",
+      configResolved(config) {
+        // Load ALL env vars (empty prefix) so COVEO_API_KEY is accessible
+        tokenEnv = loadEnv(config.mode, config.root, "");
+      },
+      configureServer(server) {
+        server.middlewares.use(async (req, res, next) => {
+          const url = new URL(req.url, `http://${req.headers.host}`);
+          if (url.pathname !== "/api/token") return next();
+
+          if (req.method !== "GET") {
+            res.statusCode = 405;
+            res.setHeader("Content-Type", "application/json");
+            res.end(JSON.stringify({ error: "Method not allowed" }));
+            return;
+          }
+
+          const result = await generateToken(tokenEnv);
+
+          res.setHeader("Content-Type", "application/json");
+          res.setHeader("Cache-Control", "no-store");
+
+          if (result.ok) {
+            res.statusCode = 200;
+            res.end(JSON.stringify({ token: result.token }));
+          } else {
+            res.statusCode = result.status;
+            res.end(JSON.stringify({ error: result.error }));
+          }
         });
       },
     },


### PR DESCRIPTION
Replaces the static Coveo API key (`xx...`) baked into the client bundle with short-lived search tokens (`ey...`) generated server-side. This enables dictionary field retrieval for the new multimarket (one source) setup, which API keys don't support.

## What changed

- New `server/token.js` — shared token generation logic (calls Coveo `/rest/search/v2/token` with `allowedDictionaryFieldKeys`)
- Vite dev plugin exposes `GET /api/token` during local dev
- Netlify function at `netlify/functions/token.js` for production
- `engine.js` refactored to async init with `renewAccessToken` for automatic 24h token renewal
- `commerceApi.js` uses token client with retry on 401/419
- Removed legacy "Logged In" toggle from navbar
- Loading spinner during token fetch
- README updated with setup instructions

## IMPORTANT: 
Change your `.env.local`

the new contents are:
```
COVEO_API_KEY={your superuser token or an "Authenticated Search" API key}
COVEO_ORG_ID="jamboreextqcrdy3"
COVEO_ENVIRONMENT="dev"
```

See README for details.