### PR TITLE
feat: add search support for sponsored products

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -1,7 +1,5 @@
-import { buildCommerceEngine } from "@coveo/headless/commerce";
-import { buildContext } from "@coveo/headless/commerce";
-import { buildRecommendations } from "@coveo/headless/commerce";
-import { getJamboree, getLocaleContext, setLocaleSlug, parseLocaleSlug } from "./configHelper";
+import { buildCommerceEngine, buildContext, buildRecommendations } from "@coveo/headless/commerce";
+import { getJamboree, getLocaleContext, parseLocaleSlug, setLocaleSlug } from "./configHelper";
 import { fetchToken } from "./tokenClient.js";
 
 const { VITE_ORGANIZATION_ID, VITE_ENVIRONMENT } = import.meta.env;
@@ -40,7 +38,10 @@ async function initEngine() {
       },
       preprocessRequest: (request) => {
         const body = request.body ? JSON.parse(request.body) : {};
-        if (request.url && request.url.includes("/listing")) {
+        if (
+          request.url &&
+          (request.url.includes("/listing") || request.url.includes("/search"))
+        ) {
           const sponsoredProducts =
             JSON.parse(localStorage.getItem("sponsored-products") || "{}") || {};
           body.pinnedProducts = sponsoredProducts?.sponsored || [];


### PR DESCRIPTION
[QA-2045](https://coveord.atlassian.net/browse/QA-2045)

Added `/search` in the supported requests for sponsored products. This will make testing the new sponsored products rule preconditions include better coverage.

Tested locally with a Search ranking rule adding a sponsor a position 3 for the 'towel' query.

Can be tested with the `SP04000_00007` product on Jamboree 2 by querying 'towel' on the preview link.

Before:
<img width="1558" height="873" alt="image" src="https://github.com/user-attachments/assets/65d7a22a-26f7-4d27-96f7-5b4f3b75aeea" />

After:
<img width="1573" height="829" alt="image" src="https://github.com/user-attachments/assets/6e519822-c94f-48a6-8a45-6e7eeefef4aa" />
